### PR TITLE
Исправил ошибки слотов

### DIFF
--- a/cstrike/addons/amxmodx/scripting/regg_informer.sma
+++ b/cstrike/addons/amxmodx/scripting/regg_informer.sma
@@ -73,7 +73,7 @@ public plugin_init() {
 public CBasePlayer_Spawn_Post(const id) <disabled> {}
 
 public CBasePlayer_Spawn_Post(const id) <enabled> {
-	if(!is_user_authorized(id)) {
+	if(!is_user_authorized(id) || !is_user_connected(id)) {
 		return;
 	}
 

--- a/cstrike/addons/amxmodx/scripting/regg_vote.sma
+++ b/cstrike/addons/amxmodx/scripting/regg_vote.sma
@@ -78,7 +78,7 @@ public ReGG_StartPre(const ReGG_Mode:mode) {
 }
 
 public CBasePlayer_Spawn(id) {
-	if(!is_user_authorized(id)) {
+	if(!is_user_authorized(id) || !is_user_connected(id)) {
 		return HC_CONTINUE;
 	}
 	if(!playerVoted[id] && voteStarted) {


### PR DESCRIPTION
Ошибки, которые были исправлены:
L 06/30/2025 - 16:25:59: Invalid slot -1
L 06/30/2025 - 16:25:59: [AMXX] Displaying debug trace (plugin "regg_informer.amxx", version "0.6.42-beta")
L 06/30/2025 - 16:25:59: [AMXX] Run time error 10: native error (native "ReGG_GetPoints")
L 06/30/2025 - 16:25:59: [AMXX]    [0] regg_informer.sma::Show_HudInformer (line 213)
L 06/30/2025 - 16:25:59: [AMXX]    [1] regg_informer.sma::CBasePlayer_Killed_Post (line 80)
L 06/30/2025 - 16:29:20: Start of error session.
L 06/30/2025 - 16:29:20: Info (map "gg_minecraftempire") (file "addons/amxmodx/logs/error_20250630.log")
L 06/30/2025 - 16:29:20: Player 13 is not in game.
L 06/30/2025 - 16:29:20: [AMXX] Displaying debug trace (plugin "regg_vote.amxx", version "0.6.42-beta")
L 06/30/2025 - 16:29:20: [AMXX] Run time error 10: native error (native "menu_display")
L 06/30/2025 - 16:29:20: [AMXX]    [0] regg_vote.sma::menu_vote (line 154)
L 06/30/2025 - 16:29:20: [AMXX]    [1] regg_vote.sma::CBasePlayer_Spawn (line 85)
